### PR TITLE
修正readme社区连接，修复zoneresolver.py中一处正则匹配问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,5 +194,5 @@ document.head.appendChild(s);
 ---
 
 * [版权声明](./GPL-2.0)
-* [BugScan 社区官网](https://www.bugscan.net)
+* [BugScan 社区官网](http://www.bugscan.net)
 * [DNSLog 示例站点](http://admin.dnslog.link/)

--- a/dnslog/zoneresolver.py
+++ b/dnslog/zoneresolver.py
@@ -35,7 +35,7 @@ class MysqlLogger():
         domain = request.q.qname.__str__()
         if domain.endswith(settings.DNS_DOMAIN + '.'):
             udomain = re.search(
-                r'\.([^\.]+)\.%s\.' % settings.DNS_DOMAIN, domain)
+                r'\.?([^\.]+)\.%s\.' % settings.DNS_DOMAIN, domain)
             if udomain:
                 user = User.objects.filter(udomain__exact=udomain.group(1))
                 if user:


### PR DESCRIPTION
```python
    def log_request(self, handler, request):
        domain = request.q.qname.__str__()
        if domain.endswith(settings.DNS_DOMAIN + '.'):
            udomain = re.search(
                r'\.?([^\.]+)\.%s\.' % settings.DNS_DOMAIN, domain)
            if udomain:
                user = User.objects.filter(udomain__exact=udomain.group(1))
                if user:
                    dnslog = DNSLog(
                        user=user[0], host=domain, type=QTYPE[request.q.qtype])
                    dnslog.save()
```
正则无法匹配xxxxx.dnslog.link,因为之前的正则是`\.([^\.]+)\.dnslog.link\.`