### PR TITLE
添加@记录支持

### DIFF
--- a/dnslog/zoneresolver.py
+++ b/dnslog/zoneresolver.py
@@ -38,6 +38,8 @@ class MysqlLogger():
                 r'\.?([^\.]+)\.%s\.' % settings.DNS_DOMAIN, domain)
             if udomain:
                 user = User.objects.filter(udomain__exact=udomain.group(1))
+                if not user and domain.strip(".") != settings.ADMIN_DOMAIN:
+                    user = User.objects.filter(udomain__exact='@')
                 if user:
                     dnslog = DNSLog(
                         user=user[0], host=domain, type=QTYPE[request.q.qtype])


### PR DESCRIPTION
允许直接配置根域名。

部分用户搭建dnslog自用，例如使用example.xxx，每次使用都需要用target_hash.mytag.example.xxx太长了，添加@支持后可以直接target_hash.example.xxx